### PR TITLE
Make WaitForIndex available outside RavenTestDriver

### DIFF
--- a/src/Raven.TestDriver/RavenTestDriver.cs
+++ b/src/Raven.TestDriver/RavenTestDriver.cs
@@ -141,7 +141,7 @@ namespace Raven.TestDriver
 
         protected event EventHandler DriverDisposed;
 
-        protected void WaitForIndexing(IDocumentStore store, string database = null, TimeSpan? timeout = null)
+        public static void WaitForIndexing(IDocumentStore store, string database = null, TimeSpan? timeout = null)
         {
             var admin = store.Maintenance.ForDatabase(database);
 


### PR DESCRIPTION
The WaitForIndex method is handy to use in test code outside a derived version of RavenTestDriver. This change marks it is public and static.